### PR TITLE
fix: pyproject package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,11 @@ dev = [
     "pytest>=9.0.1",
     "ruff>=0.14.6",
 ]
+
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["dto*", "models*"]
+


### PR DESCRIPTION
Using `pip install .`failed with "Multiple top-level packages exist (e.g. `dto`, `models`)"
Apparently the implicit package discovery did not work? But this fixed it for me at least.