### PR TITLE
refactor: require admin permissions for creating users

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+from typing import cast
 from project_utils import check_value_within_bounds
 from webauthn_handlers import (
     webauthn_authenticate,
@@ -64,7 +65,7 @@ import project_utils
 from helpers import is_valid_email
 
 from sqlalchemy import select, exists, and_, delete as sa_delete
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from advanced_alchemy.extensions.litestar import (
     AsyncSessionConfig,
@@ -126,18 +127,6 @@ async def has_project_lead_permissions(
         db_session, project_id=project_id, user_id=str(request.user.id)
     )
     return actor_role == UserRole.LEADER
-
-
-@get("/hello")
-async def hello_world(
-    db_session: AsyncSession, db_engine: AsyncEngine
-) -> dict[str, str]:
-    """
-    Prints hello world.
-
-    return: a JSON object
-    """
-    return {"hello": "world"}
 
 
 @get(["/", "/health", "/healthz"], include_in_schema=False)
@@ -555,7 +544,7 @@ class CreateUserRequest:
 # TODO: replace with path "/users" once this route is part of the authentication router group
 @post("/users/create")
 async def create_user(
-    db_session: AsyncSession, data: CreateUserRequest
+    db_session: AsyncSession, data: CreateUserRequest, request: Request
 ) -> SuccessResponse:
     """
     Create a new user.
@@ -563,6 +552,10 @@ async def create_user(
     param data: the user data to create a new user from
     return: whether the user was successfully created
     """
+    user = cast(User, request.user)
+    if not user.is_admin:
+        raise PermissionDeniedException("only admins may create new users")
+
     if is_valid_email(data.name):
         raise ClientException("usernames must not be an e-mail addresses!")
 
@@ -1291,6 +1284,7 @@ authenticated_router = Router(
         webauthn_get_registration_options,
         webauthn_remove_credentials,
         webauthn_is_configured,
+        create_user,
     ],
     middleware=[AuthenticationMiddleware],
     tags=["authenticated"],
@@ -1301,13 +1295,10 @@ authenticated_router = Router(
 public_router = Router(
     path="/",
     route_handlers=[
-        hello_world,
         main_page,
         login_handler,
         webauthn_authenticate,
         webauthn_get_authentication_options,
-        # TODO: creating users should not be possible without authentication!
-        create_user,
     ],
     tags=["public"],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from litestar.status_codes import (
 )
 from litestar.testing import TestClient
 from app import app
+from utils import login
 
 import uuid
 
@@ -24,6 +25,9 @@ def test_user(client):
             "name": name,
             "email": "test@example.com",
             "password": "testpassword123",
+        },
+        cookies={
+            "token": login(client, "admin", "password"),
         },
     )
     assert response.status_code == HTTP_201_CREATED

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,6 +7,7 @@ from app import app
 from models.user import User
 from authentication import create_jwt, verify_jwt
 from time import sleep
+from utils import login
 
 app.debug = True
 
@@ -20,6 +21,9 @@ def test_create_invalid_user(client):
             "email": "example@test.com",
             "password": "testpassword123",
         },
+        cookies={
+            "token": login(client, "admin", "password"),
+        },
     )
     assert response.status_code == HTTP_400_BAD_REQUEST
 
@@ -30,6 +34,9 @@ def test_create_invalid_user(client):
             "name": "foobar",
             "email": "email-without-at-sign",
             "password": "testpassword123",
+        },
+        cookies={
+            "token": login(client, "admin", "password"),
         },
     )
     assert response.status_code == HTTP_400_BAD_REQUEST

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+from litestar.testing import TestClient
 import uuid
 
 from litestar.status_codes import (
@@ -61,6 +62,12 @@ def create_task(client, key_result_id):
     return task.json()[-1].get("id")
 
 
+def login(client: TestClient, username, password) -> str:
+    response = client.post("/login", json={"name": username, "password": password})
+    assert response.status_code == HTTP_201_CREATED
+    return response.cookies["token"]
+
+
 def create_user(client, name=None, email=None):
     if name is None:
         name = f"test-user-{uuid.uuid4()}"
@@ -71,6 +78,9 @@ def create_user(client, name=None, email=None):
             "name": name,
             "email": email,
             "password": "testpassword123",
+        },
+        cookies={
+            "token": login(client, "admin", "password"),
         },
     )
     assert user.status_code == HTTP_201_CREATED


### PR DESCRIPTION
Now that https://github.com/tpse-81/okr-frontend/pull/71 is merged, we can now enforce admin permissions on the backend for creating new users.