### PR TITLE
feat: also reset 2fa options when resetting password via admin interface

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,6 +39,7 @@ from authentication import (
     totp_disable,
     logout,
     get_user_by_name_or_mail,
+    reset_password,
 )
 
 from dto.write_dto import (
@@ -1332,6 +1333,7 @@ authenticated_router = Router(
         get_user_role,
         add_objective_to_objective,
         change_password,
+        reset_password,
         totp_setup,
         totp_confirm,
         totp_disable,

--- a/authentication.py
+++ b/authentication.py
@@ -1,7 +1,7 @@
 from webauthn_handlers import try_authenticate_user
 from enum import Enum
 from dataclasses import dataclass
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 import typing
 import re
 import pyotp
@@ -154,6 +154,11 @@ class ChangePasswordRequest:
     new_password: str
 
 
+@dataclass
+class ResetPasswordRequest:
+    new_password: str
+
+
 class TwoFaType(str, Enum):
     WEBAUTHN = "webauthn"
     TOTP = "totp"
@@ -294,19 +299,52 @@ def verify_password(password_hash: str, password: str) -> bool:
         return False
 
 
-@patch("/users/{user_id:str}/password/change")
+@patch("/users/password/change")
 async def change_password(
     request: Request,
     db_session: AsyncSession,
-    user_id: str = Parameter(),
     data: ChangePasswordRequest = Body(title="Change Password Request"),
 ) -> SuccessResponse:
     """
     Change a user's password.
 
-    param user_id: ID of the user whose password should be changed
     param data: old and new password
     """
+    user = cast(User, request.user)
+
+    # load user
+    user_query = await db_session.execute(select(User).where(User.id == user.id))
+    user = user_query.scalar_one_or_none()
+    if not user:
+        raise NotFoundException("User not found")
+
+    # verify old password
+    if not verify_password(user.password_hash, data.old_password):
+        raise NotAuthorizedException("Old password is incorrect")
+
+    # hash and store new password
+    user.password_hash = hash_password(data.new_password)
+    await db_session.commit()
+
+    return SuccessResponse("password successfully changed")
+
+
+@patch("/users/{user_id:str}/password/reset")
+async def reset_password(
+    request: Request,
+    db_session: AsyncSession,
+    user_id: str = Parameter(),
+    data: ResetPasswordRequest = Body(title="Reset Password Request"),
+) -> SuccessResponse:
+    """
+    Reset a user's authentication by changing the password to the given new password and removing 2FA.
+
+    param user_id: ID of the user whose password should be changed
+    param data: new password
+    """
+    actor = cast(User, request.user)
+    if not actor.is_admin:
+        raise PermissionDeniedException("Not allowed")
 
     # load user
     user_query = await db_session.execute(select(User).where(User.id == user_id))
@@ -320,13 +358,11 @@ async def change_password(
     if not actor.is_admin and str(actor.id) != user_id:
         raise PermissionDeniedException("Not allowed")
 
-    # verify old password
-    if not actor.is_admin:
-        if not verify_password(user.password_hash, data.old_password):
-            raise NotAuthorizedException("Old password is incorrect")
-
     # hash and store new password
     user.password_hash = hash_password(data.new_password)
+    user.two_fa_secret = None
+    if user.webauthn:
+        await db_session.delete(user.webauthn)
     await db_session.commit()
 
     return SuccessResponse("password successfully changed")
@@ -419,7 +455,7 @@ async def totp_disable(
         return SuccessResponse("TOTP 2FA already disabled")
 
     if pending:
-        user.two_fa_secret = ""
+        user.two_fa_secret = None
         await db_session.commit()
         return SuccessResponse("pending TOTP setup cleared")
 
@@ -427,7 +463,7 @@ async def totp_disable(
     if not code or not verify_totp(secret, code):
         raise ClientException("invalid 2FA code")
 
-    user.two_fa_secret = ""
+    user.two_fa_secret = None
     await db_session.commit()
     return SuccessResponse("TOTP 2FA disabled")
 

--- a/models/user.py
+++ b/models/user.py
@@ -21,7 +21,7 @@ class User(base.UUIDBase):
     name: Mapped[str] = mapped_column(nullable=False, unique=True, index=True)
     email: Mapped[str] = mapped_column(unique=True, index=True)
     password_hash: Mapped[str]
-    two_fa_secret: Mapped[str]
+    two_fa_secret: Mapped[str | None]
     is_admin: Mapped[bool] = mapped_column(default=False, nullable=False)
 
     # N->N relationship with Project

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,13 +1,15 @@
+from litestar.testing import TestClient
 from litestar.status_codes import (
     HTTP_201_CREATED,
     HTTP_400_BAD_REQUEST,
+    HTTP_200_OK,
 )
 
 from app import app
 from models.user import User
 from authentication import create_jwt, verify_jwt
 from time import sleep
-from utils import login
+from utils import create_user, login
 
 app.debug = True
 
@@ -101,3 +103,29 @@ def test_not_username_but_email(client, test_user):
     )
 
     assert response.status_code == HTTP_201_CREATED
+
+
+def test_change_password(client: TestClient, test_user):
+    token = login(client, username=test_user["name"], password=test_user["password"])
+    response = client.patch(
+        "/users/password/change",
+        json={"old_password": test_user["password"], "new_password": "newpassword"},
+        cookies={
+            "token": token,
+        },
+    )
+    assert response.status_code == HTTP_200_OK
+
+    login(client, username=test_user["name"], password="newpassword")
+
+
+def test_reset_password(client: TestClient):
+    u = create_user(client, name="reset-test", email="reset@password.com")
+    response = client.patch(
+        f"/users/{u}/password/reset",
+        json={"new_password": "newpassword"},
+        cookies={"token": login(client, "admin", "password")},
+    )
+    assert response.status_code == HTTP_200_OK
+
+    login(client, username="reset-test", password="newpassword")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ import uuid
 
 from litestar.status_codes import (
     HTTP_201_CREATED,
+    HTTP_200_OK,
 )
 
 from app import app
@@ -69,6 +70,10 @@ def login(client: TestClient, username, password) -> str:
 
 
 def create_user(client, name=None, email=None):
+    admin_cookies = {
+        "token": login(client, "admin", "password"),
+    }
+
     if name is None:
         name = f"test-user-{uuid.uuid4()}"
     email = email or f"{name.lower()}@test.com"
@@ -79,10 +84,9 @@ def create_user(client, name=None, email=None):
             "email": email,
             "password": "testpassword123",
         },
-        cookies={
-            "token": login(client, "admin", "password"),
-        },
+        cookies=admin_cookies,
     )
     assert user.status_code == HTTP_201_CREATED
-    user = client.get("/users")
+    user = client.get("/users", cookies=admin_cookies)
+    assert user.status_code == HTTP_200_OK
     return user.json()[-1]["id"]


### PR DESCRIPTION
The reset and change password methods differ a lot, so they should be split up:
- reset password: admin resets password and 2fa for a user
- change password: a user changes their OWN password

this also requires some small frontend changes

closes https://github.com/tpse-81/okr/issues/91