### PR TITLE
feat: changed dto so that tasks now also return key result id

### DIFF
--- a/dto/read_dto.py
+++ b/dto/read_dto.py
@@ -37,8 +37,6 @@ class TaskReadDTO(SQLAlchemyDTO[Task]):
     DTO used for serializing Task models for read operations (limits output and prevents recursive relationships)
     """
 
-    config = DTOConfig(exclude={"key_result_id"})
-
 
 class UserReadDTO(SQLAlchemyDTO[User]):
     """


### PR DESCRIPTION
Closes github.com/tpse-81/okr-frontend/issues/99

It really was just removing the key result id value from the exclude config, but for some reason i have to reinstall sqlalchemy everytime after changing dtos for the changes to actually show up